### PR TITLE
Modélisation relationsphip (foreign_keys, primaryjoin)(l'issue 39) 

### DIFF
--- a/hoozhoo/modeles/donnees.py
+++ b/hoozhoo/modeles/donnees.py
@@ -19,8 +19,8 @@ class Person(db.Model):
     person_external_id = db.Column(db.String(45))
 # Jointure
     authorships_p = db.relationship("Authorship_person", back_populates="person")
-    link_pers1 = db.relationship("Link", back_populates="person1")
-    link_pers2 =  db.relationship("Link", back_populates="person2")
+    link_pers1 = db.relationship("Link", primaryjoin="Person.person_id==Link.link_person1_id")
+    link_pers2 = db.relationship("Link", primaryjoin="Person.person_id==Link.link_person2_id")
 
 class Relation_type(db.Model):
     __tablename__ = "relation_type"
@@ -42,8 +42,8 @@ class Link(db.Model):
     link_relation_type_id = db.Column(db.Integer, db.ForeignKey('relation_type.relation_type_id'))
 # Jointure
     relations = db.relationship("Relation_type", back_populates="type_link")
-    person1 = db.relationship("Person", back_populates="link_pers1")
-    person2 = db.relationship("Person", back_populates="link_pers2")
+    person1 = db.relationship("Person", foreign_keys=[link_person1_id])
+    person2 = db.relationship("Person", foreign_keys=[link_person2_id])
     authorships_l = db.relationship ("Authorship_link", back_populates="link_link")
 
 class Authorship_link(db.Model):

--- a/hoozhoo/routes/generic.py
+++ b/hoozhoo/routes/generic.py
@@ -14,3 +14,22 @@ def debut():
 def about():
     return render_template("pages/about.html")
 
+@app.route("/index")
+def index():
+    """
+    Route qui affiche la liste des personnes (Nom, prenom) de la base.
+    """
+    personnes = Person.query.all()
+    return render_template("pages/index.html", personnes=personnes)
+
+
+
+@app.route("/person/<int:identifier>")
+def notice(identifier):
+    """
+    Route qui affiche la notice descriptive de la personne
+    :param identifier: identifiant numérique de la personne
+    """
+    personne = Person.query.get(identifier)
+    return render_template("pages/notice.html", personne=personne)
+

--- a/hoozhoo/templates/pages/index.html
+++ b/hoozhoo/templates/pages/index.html
@@ -1,0 +1,16 @@
+{% extends "conteneur.html" %}
+{% block corps %}
+
+<h1>Bienvenue !</h1>
+    {% if personnes %}
+    <p>Il y a {{personnes|length}} personnes enregistrées :</p>
+        <ul>
+            {% for personne in personnes %}
+                <li><a href="{{url_for("notice", identifier=personne.person_id)}}">{{personne.person_name}} {{personne.person_firstname}}</a></li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        <p>La base de données est en cours de constitution</p>
+    {% endif %}
+
+{% endblock %}

--- a/hoozhoo/templates/pages/notice.html
+++ b/hoozhoo/templates/pages/notice.html
@@ -1,0 +1,6 @@
+{% extends "conteneur.html" %}
+{% block corps %}
+
+<h1>Bienvenue !</h1>
+    <p>La notice est en construction</p>
+{% endblock %}


### PR DESCRIPTION
Modélisation des relationship des classes Personn et Link avec foreign_keys et primaryjoin. Suite aux discussions dans l'issue #39 
Lancement de la page index et notice. 