### PR TITLE
ajout du block title dans la page à propos

### DIFF
--- a/hoozhoo/templates/pages/about.html
+++ b/hoozhoo/templates/pages/about.html
@@ -1,4 +1,5 @@
 {% extends "conteneur.html" %}
+{% block titre %}| A propos{% endblock %}
 {% block corps %}
 <h1>A propos du projet Hoozhoo</h1>
 <p>Cette application a été développée dans le cadre d'une évaluation pour le cours de Python du Master 2 Technologies numériques appliquées à l'histoire de l'Ecole nationale des chartes. Elle vise à permettre la mise en place d'un dictionnaire prosopographique incluant une gestion des relations entre personnes, sur la base de l'<a href="https://snapdrgn.net/ontology">ontologie SNAP</a>.</p>


### PR DESCRIPTION
J'ajoute le block title pour être en phase avec les autres pages qui ont été créées jusqu'à présent. 
#26 