### PR TITLE
Mise à jour page Notice

### DIFF
--- a/hoozhoo/templates/conteneur.html
+++ b/hoozhoo/templates/conteneur.html
@@ -12,7 +12,7 @@
 				<a class="navbar-brand" href="#">Hoozhoo</a>
 					<ul class="navbar-nav mr-auto">
 						<li class="nav-item">
-							<a class="nav-link" href="#">Index</a>
+							<a class="nav-link" href="{{url_for("index")}}">Index</a>
 						</li>
 						<li class="nav-item">
 							<a class="nav-link" href="#">Contribuer</a>

--- a/hoozhoo/templates/pages/notice.html
+++ b/hoozhoo/templates/pages/notice.html
@@ -17,12 +17,15 @@
                 <dt>
                     {{lien.relations.relation_type_name}}
                 </dt>
-                <dd>{{lien.person2.person_name}} {{lien.person2.person_firstname}} {{lien.person2.person_nickname}}</dd>
+                <dd><a href="{{url_for('notice', identifier=lien.person2.person_id)}}">{{lien.person2.person_name}} {{lien.person2.person_firstname}} {{lien.person2.person_nickname}}</a></dd>
             {% endfor %}
         </dl>
     {% else %}
         <p>La base de données est en cours de constitution</p>
     {% endif %}
-    <p><a href="{{url_for('index')}}">Retour à l'index</a></p>
+    <div>
+        <a href="#routeModif" class="btn btn-secondary">Modifier la notice de la personne</a>
+        <a href="{{url_for('creer_lien')}}" class="btn btn-secondary">Créer des liens entre les personnes</a>
+    </div>
 
 {% endblock %}

--- a/hoozhoo/templates/pages/notice.html
+++ b/hoozhoo/templates/pages/notice.html
@@ -1,6 +1,6 @@
 {% extends "conteneur.html" %}
 {% block titre %}
-    {%if unique %}| unique : {{unique.person_name}} {{unique.person_firstname}} {{unique.person_nickname}} {% endif %}
+    {%if unique %}| {{unique.person_name}} {{unique.person_firstname}} {{unique.person_nickname}} {% endif %}
 {% endblock %}
 
 {% block corps %}


### PR DESCRIPTION
Mise à jour de la page Notice avec les éléments suivants:
des liens url pour les personnes liées à la personne principale de la notice 
un lien url pour l'index dans conteneur 
2 boutons :un pour modifier la notice(qui sera activé au moment de la création du formulaire de modification) et un qui renvoie vers "créer lien". 