### PR TITLE
Petite correction dans le title (conteneur)

### DIFF
--- a/hoozhoo/templates/conteneur.html
+++ b/hoozhoo/templates/conteneur.html
@@ -3,7 +3,7 @@
 		<head>
 			<meta charset="UTF-8">
 			<link rel="icon" type="image/png" href="../static/images/chouette.png" />
-			<title>Hoozoo {%block titre %}{%endblock%}</title>
+			<title>Hoozhoo {%block titre %}{%endblock%}</title>
 			{% include "partials/css.html" %}
         	{% include "partials/metadata.html" %}
 		</head>


### PR DESCRIPTION
Avec @lduflos nous avions relevé qu'il manquait un "h" à Hoozhoo dans le header. 