### PR TITLE
Ajout de la fonction "modifier un lien"

### DIFF
--- a/hoozhoo/modeles/donnees.py
+++ b/hoozhoo/modeles/donnees.py
@@ -311,28 +311,33 @@ class Link(db.Model):
         if len(errors) > 0:
             return False, errors
 
-        # on récupère le lien dans la base 
-        origin_link = Link.query.get(id)
         # on récupère l'id du type de relation 
         relation_id = Relation_type.query.filter(Relation_type.relation_type_name == link_relation_type).all()
+        relation_type = relation_id[0]
+        id_relation = relation_type.relation_type_id
 
+        # on récupère le lien dans la base 
+        origin_link = Link.query.get(id)
         # on vérifie qu'une modification a été effectuée : 
-        if origin_link.link_person1_id == link_person1_id and origin_link.link_person2_id == link_person2_id and origin_link.link_relation_type_id == relation_id:
+        if origin_link.link_person1_id == link_person1_id and origin_link.link_person2_id == link_person2_id and origin_link.link_relation_type_id == id_relation:
             errors.append("Aucune modification n'a été réalisée")
         if len(errors) > 0:
             return False, errors
 
         # on vérifie que le lien n'existe pas déjà
         uniques = Link.query.filter(
-            db.and_(Link.link_id != id, Link.link_person1_id == link_person1_id, Link.link_person2_id == link_person2_id, Link.link_relation_type_id == relation_id)
+            db.and_(Link.link_id != id, Link.link_person1_id == link_person1_id, Link.link_person2_id == link_person2_id, Link.link_relation_type_id == id_relation)
             ).count()
         if uniques > 0:
             errors.append("le lien modifié existe déjà")
 
+        if len(errors) > 0:
+            return False, errors
+
         # mise à jour du lien
         origin_link.link_person1_id=link_person1_id
         origin_link.link_person2_id=link_person2_id
-        origin_link.link_relation_type_id=relation_id
+        origin_link.link_relation_type_id=id_relation
 
         try:
             # ajout de la mise à jour du lien dans la base de données

--- a/hoozhoo/modeles/donnees.py
+++ b/hoozhoo/modeles/donnees.py
@@ -264,7 +264,7 @@ class Link(db.Model):
         """
 
         errors = []
-        
+
         # on vérifie que tous les paramètres sont complétés : 
         if not id:
             errors.append("erreur d'identification du lien à éditer")
@@ -280,13 +280,14 @@ class Link(db.Model):
         if len(errors) > 0:
             return False, errors
 
-        # on récupère le lien original dans la base 
-        origin_link = Link.query.get(id)
-        # on vérifie qu'une modification a été effectuée : 
-        if origin_link.link_person1_id == link_person1_id and origin_link.link_person2_id == link_person2_id and origin_link.link_relation_type_id == link_relation_type:
-            errors.append("Aucune modification n'a été réalisée")
+        exist = Person.query.get(link_person2_id)
+        if not exist:
+            errors.append(link_person2_id + " n'est pas un identifiant valide")
         if len(errors) > 0:
             return False, errors
+
+        # on récupère le lien original dans la base 
+        origin_link = Link.query.get(id)
 
         # on vérifie que le lien n'existe pas déjà
         uniques = Link.query.filter(

--- a/hoozhoo/modeles/donnees.py
+++ b/hoozhoo/modeles/donnees.py
@@ -172,22 +172,23 @@ class Link(db.Model):
         Sinon, elle renvoie True, suivi d'une liste de données enregistrées.
         :param link_person1: liste de noms de la personne 1
         :param link_person2: liste de noms de la personne 2
-        :param link_relation_type: liste de noms de la relation (modele SNAP)
+        :param link_relation_type: liste d'id numérique de relation, ou bien "choisir"
         """
+        print("TEST")
+        print(link_person1)
+        print(link_person2)
+        print(link_relation_type)
 
         errors = []
 
         # On vérifie que les champs de toutes les lignes sont remplis
         if not( (len(link_person1) == len(link_person2)) and (len(link_person1) == len(link_relation_type)) and (len(link_person2) == len(link_relation_type)) ):
             errors.append("certains champs sont vides")
-
-        # Premier niveau d'interruption si erreurs.
         if len(errors) > 0:
             return False, errors
 
         # Calcul du nombre d'itérations nécessaire pour la boucle
         loop = len(link_person1)
-
         # On vérifie qu'aucune ligne n'est identique à une autre
         triplets = []
         repeat = 0
@@ -199,15 +200,12 @@ class Link(db.Model):
             triplets.append(triplet)
         if repeat > 0:
             errors.append("certains liens à créer sont identiques")
-
         # on vérifie que le type de relation a bien été séléctionné, et que les champs pers1 et pers2 ne sont pas identiques:
         for row in range (0, loop):
             if link_relation_type[row] == 'Choisir':
                 errors.append("aucun type de relation n'a été sélectionné, ligne " + str(row +1))
             if link_person1[row] == link_person2[row]:
                 errors.append("les champs 'Personne 1' et 'Personne 2' sont identiques, ligne " + str(row +1))
-
-        # Deuxième niveau d'interruption si erreurs.
         if len(errors) > 0:
             return False, errors
 
@@ -215,47 +213,27 @@ class Link(db.Model):
         for row in range (0, loop):
             person1 = Person.query.filter(Person.person_id == link_person1[row]).count()
             person2 = Person.query.filter(Person.person_id == link_person2[row]).count()
-
             if person1 == 0:
                 errors.append(link_person1[row] +" n'existe pas, ligne " + str(row +1))
             if person2 == 0:
                 errors.append(link_person2[row] +" n'existe pas, ligne " + str(row +1))
-
-            # Il est possible que ce test ne soit pas nécessaire :
-            # On récupère l'id de la relation dans la table Relation_type :
-            c_relation = Relation_type.query.filter(Relation_type.relation_type_name == link_relation_type[row]).count()
-            # On vérifie que la requête d'id de relation a bien fonctionné
-            if c_relation == 0:
-                errors.append("erreur de lien, ligne " + str(row +1))
-
-        # Troisième niveau d'interruption si erreurs. Liste des erreurs sur tout le formulaire.
         if len(errors) > 0:
             return False, errors
 
-        # On récupère l'id associé au lien.
+        # On vérifie que le lien n'existe pas déjà
         for row in range (0, loop):
-            relation = Relation_type.query.filter(Relation_type.relation_type_name == link_relation_type[row]).all()
-            u_relation = relation[0]
-            link_relation_type[row] = u_relation.relation_type_id
-
-            # On vérifie que le lien n'existe pas déjà
             uniques = Link.query.filter(
                 db.and_(Link.link_person1_id == link_person1[row], Link.link_person2_id == link_person2[row], Link.link_relation_type_id == link_relation_type[row])
                 ).count()
             if uniques > 0:
                 errors.append("le lien existe déjà")
-
-        # Quatrième niveau d'interruption si erreurs.
         if len(errors) > 0:
             return False, errors
 
-        # Sinon, on itère à nouveau pour créer un lien :
+        # On itère à nouveau pour créer un lien :
         # la liste created_link va récupérer l'ensemble des données enregistrées
         created_link = []
         for row in range (0, loop):
-            # re-création de la variable relation
-            relation = Relation_type.query.filter(Relation_type.relation_type_name == link_relation_type[row]).all()
-
             created_link.append(
                 Link(
                     link_person1_id=link_person1[row],
@@ -269,15 +247,12 @@ class Link(db.Model):
                 # Phase de création du lien :
                 db.session.add(created_link[row])
                 db.session.commit()
-
             # Renvoie d'informations vers l'utilisateur :
             return True, created_link
 
         # Sinon renvoie l'erreur vers l'utilisateur :
         except Exception as error_creation:
             return False, [str(error_creation)]
-
-
 
 
     @staticmethod

--- a/hoozhoo/modeles/donnees.py
+++ b/hoozhoo/modeles/donnees.py
@@ -174,10 +174,6 @@ class Link(db.Model):
         :param link_person2: liste de noms de la personne 2
         :param link_relation_type: liste d'id numérique de relation, ou bien "choisir"
         """
-        print("TEST")
-        print(link_person1)
-        print(link_person2)
-        print(link_relation_type)
 
         errors = []
 
@@ -263,7 +259,7 @@ class Link(db.Model):
         Sinon, elle renvoie True, suivi de la donnée enregistrée.
         :param id : un identifiant numérique du lien
         :param link_person1_id : un identifiant numérique de la personne 1
-        :param link_relation_type : une chaine de caractère correspondant à un type de relation 
+        :param link_relation_type : un identifiant numérique du type de relation  
         :param link_person2_id : un identifiant numérique de la personne 2
         """
 
@@ -281,38 +277,30 @@ class Link(db.Model):
         # on vérifie que personne 1 et personne 2 ne sont pas identiques 
         if link_person1_id == link_person2_id:
             errors.append("personne 1 et personne 2 ne peuvent pas être identiques")
-
-        # s'il y a des erreurs, on interrompt le processus
         if len(errors) > 0:
             return False, errors
 
-        # on récupère l'id du type de relation 
-        relation_id = Relation_type.query.filter(Relation_type.relation_type_name == link_relation_type).all()
-        relation_type = relation_id[0]
-        id_relation = relation_type.relation_type_id
-
-        # on récupère le lien dans la base 
+        # on récupère le lien original dans la base 
         origin_link = Link.query.get(id)
         # on vérifie qu'une modification a été effectuée : 
-        if origin_link.link_person1_id == link_person1_id and origin_link.link_person2_id == link_person2_id and origin_link.link_relation_type_id == id_relation:
+        if origin_link.link_person1_id == link_person1_id and origin_link.link_person2_id == link_person2_id and origin_link.link_relation_type_id == link_relation_type:
             errors.append("Aucune modification n'a été réalisée")
         if len(errors) > 0:
             return False, errors
 
         # on vérifie que le lien n'existe pas déjà
         uniques = Link.query.filter(
-            db.and_(Link.link_id != id, Link.link_person1_id == link_person1_id, Link.link_person2_id == link_person2_id, Link.link_relation_type_id == id_relation)
+            db.and_(Link.link_id != id, Link.link_person1_id == link_person1_id, Link.link_person2_id == link_person2_id, Link.link_relation_type_id == link_relation_type)
             ).count()
         if uniques > 0:
             errors.append("le lien modifié existe déjà")
-
         if len(errors) > 0:
             return False, errors
 
         # mise à jour du lien
         origin_link.link_person1_id=link_person1_id
         origin_link.link_person2_id=link_person2_id
-        origin_link.link_relation_type_id=id_relation
+        origin_link.link_relation_type_id=link_relation_type
 
         try:
             # ajout de la mise à jour du lien dans la base de données

--- a/hoozhoo/routes/generic.py
+++ b/hoozhoo/routes/generic.py
@@ -155,34 +155,28 @@ def modification_lien(identifier):
     Route qui affiche un lien existant dans la base pour l'éditer
     :param identifier: identifiant numérique du lien
     """
-    if request.method == "GET":
-        lienUnique = Link.query.get(identifier)
-        type_relation = Relation_type.query.filter(Relation_type.relation_type_id == lienUnique.link_relation_type_id).all()
-        relation = type_relation[0]
-        relation_name = relation.relation_type_name
-        return render_template("pages/modification_lien.html", unique=lienUnique, relation_name=relation_name)
+    listRelation = Relation_type.query.all()
+    lienUnique = Link.query.get(identifier)
 
-        # sinon en méthode POST : 
-    # VERIFIER CETTE METHODE
+    if request.method == "GET":
+        return render_template("pages/modification_lien.html", unique=lienUnique, listRelation=listRelation)
+
+    # sinon en méthode POST : 
     else: 
+        personneOrigine = request.form.get("link_1_person", None)
+        personneUnique = Person.query.get(personneOrigine)
+        
         status, data = Link.modifier_link(
             id = identifier,
-            link_person1_id = request.form.get("link_1_person", None),
+            link_person1_id = personneOrigine,
             link_relation_type = request.form.get("link_relation_type", None),
             link_person2_id = request.form.get("link_2_person", None)
             )
 
-        personneOrigine = request.form.get("link_1_person", None)
-        personneUnique = Person.query.get(personneOrigine)
-
         if status is True :
             flash("Modification réussie !", "success")
-            return render_template ("pages/notice.html", unique=personneUnique, listLien=personneUnique.link_pers1)
+            return render_template("pages/notice.html", unique=personneUnique, listLien=personneUnique.link_pers1)
 
         else:
             flash("Les erreurs suivantes empêchent l'édition du lien : " + ",".join(data), "danger")
-            lienUnique = Link.query.get(identifier)
-            type_relation = Relation_type.query.filter(Relation_type.relation_type_id == lienUnique.link_relation_type_id).all()
-            relation = type_relation[0]
-            relation_name = relation.relation_type_name
-            return render_template("pages/modification_lien.html", unique=lienUnique, relation_name=relation_name)
+            return render_template("pages/modification_lien.html", unique=lienUnique, listRelation=listRelation)

--- a/hoozhoo/routes/generic.py
+++ b/hoozhoo/routes/generic.py
@@ -154,10 +154,28 @@ def modification_lien(identifier):
     Route qui affiche un lien existant dans la base pour l'éditer
     :param identifier: identifiant numérique du lien
     """
-    print(identifier)
     if request.method == "GET":
         lienUnique = Link.query.get(identifier)
         type_relation = Relation_type.query.filter(Relation_type.relation_type_id == lienUnique.link_relation_type_id).all()
         relation = type_relation[0]
         relation_name = relation.relation_type_name
         return render_template("pages/modification_lien.html", unique=lienUnique, relation_name=relation_name)
+
+        # sinon en méthode POST : 
+    # VERIFIER CETTE METHODE
+    else: 
+        status, data = Link.modifier_link(
+            id = identifier,
+            link_person1_id = request.form.get("link_1_person", None),
+            link_relation_type = request.form.get("link_relation_type", None),
+            link_person2_id = request.form.get("link_2_person", None)
+            )
+
+        if status is True :
+            flash("Modification réussie !", success)
+            unique = Person.query.get(data.link_person1_id)
+            return render_template ("pages/notice.html", unique=unique, listLien=unique.link_pers1)
+
+        else:
+            flash("Les erreurs suivantes empêchent l'édition du lien : " + ",".join(data), "danger")
+            return render_template("pages/modification_lien.html", identifier=identifier)

--- a/hoozhoo/routes/generic.py
+++ b/hoozhoo/routes/generic.py
@@ -54,12 +54,13 @@ def notice(identifier):
     return render_template("pages/notice.html", unique=personneUnique, listLien=listLien)
 
 @app.route("/creer-lien", methods=["GET", "POST"])
-#@login_required #désactivé pour le test
 def creer_lien():
-    """ route permettant à un utilisateur enregistré de créer un ou plusieurs liens entre des personnes existant dans la base
     """
+    route permettant à un utilisateur enregistré de créer un ou plusieurs liens entre des personnes existant dans la base
+    """
+    listRelation = Relation_type.query.all()
+
     if request.method == "POST":
-        # méthode statique create_link() à créer sous Link
         status, data = Link.create_link(
         link_person1=request.form.getlist("link_1_person[]", None),
         link_relation_type=request.form.getlist("link_relation_type[]", None),
@@ -67,14 +68,14 @@ def creer_lien():
         )
 
         if status is True:
-            flash("Création d'un nouveau lien réussie !", "success")
+            flash("Création de lien(s) réussie !", "success")
             return redirect("/creer-lien")
-        else:
-            flash("La création d'un nouveau lien a échoué pour les raisons suivantes : " + ", ".join(data), "danger")
-            return render_template("pages/creer_lien.html")
 
+        else:
+            flash("La création de lien(s) a échoué pour les raisons suivantes : " + ",".join(data), "danger")
+            return render_template("pages/creer_lien.html", listRelation=listRelation)
     else:
-        return render_template("pages/creer_lien.html")
+        return render_template("pages/creer_lien.html", listRelation=listRelation)
 
 
 @app.route("/modification/<int:identifier>", methods=["POST", "GET"])

--- a/hoozhoo/routes/generic.py
+++ b/hoozhoo/routes/generic.py
@@ -171,11 +171,17 @@ def modification_lien(identifier):
             link_person2_id = request.form.get("link_2_person", None)
             )
 
+        personneOrigine = request.form.get("link_1_person", None)
+        personneUnique = Person.query.get(personneOrigine)
+
         if status is True :
-            flash("Modification réussie !", success)
-            unique = Person.query.get(data.link_person1_id)
-            return render_template ("pages/notice.html", unique=unique, listLien=unique.link_pers1)
+            flash("Modification réussie !", "success")
+            return render_template ("pages/notice.html", unique=personneUnique, listLien=personneUnique.link_pers1)
 
         else:
             flash("Les erreurs suivantes empêchent l'édition du lien : " + ",".join(data), "danger")
-            return render_template("pages/modification_lien.html", identifier=identifier)
+            lienUnique = Link.query.get(identifier)
+            type_relation = Relation_type.query.filter(Relation_type.relation_type_id == lienUnique.link_relation_type_id).all()
+            relation = type_relation[0]
+            relation_name = relation.relation_type_name
+            return render_template("pages/modification_lien.html", unique=lienUnique, relation_name=relation_name)

--- a/hoozhoo/routes/generic.py
+++ b/hoozhoo/routes/generic.py
@@ -1,6 +1,6 @@
 from flask import render_template, request, flash, redirect
 from ..app import app
-from ..modeles.donnees import Person, Link
+from ..modeles.donnees import Person, Link, Relation_type
 from ..modeles.utilisateurs import User
 
 #variable à utiliser pour la pagination de la page recherche et index
@@ -148,3 +148,16 @@ def creer_personne():
 def contact():
     return render_template("pages/contact.html")
 
+@app.route("/modifier/lien/<int:identifier>", methods=["GET", "POST"])
+def modification_lien(identifier):
+    """
+    Route qui affiche un lien existant dans la base pour l'éditer
+    :param identifier: identifiant numérique du lien
+    """
+    print(identifier)
+    if request.method == "GET":
+        lienUnique = Link.query.get(identifier)
+        type_relation = Relation_type.query.filter(Relation_type.relation_type_id == lienUnique.link_relation_type_id).all()
+        relation = type_relation[0]
+        relation_name = relation.relation_type_name
+        return render_template("pages/modification_lien.html", unique=lienUnique, relation_name=relation_name)

--- a/hoozhoo/routes/generic.py
+++ b/hoozhoo/routes/generic.py
@@ -149,7 +149,7 @@ def creer_personne():
 def contact():
     return render_template("pages/contact.html")
 
-@app.route("/modifier/lien/<int:identifier>", methods=["GET", "POST"])
+@app.route("/modifierlien/<int:identifier>", methods=["GET", "POST"])
 def modification_lien(identifier):
     """
     Route qui affiche un lien existant dans la base pour l'éditer

--- a/hoozhoo/routes/generic.py
+++ b/hoozhoo/routes/generic.py
@@ -164,7 +164,6 @@ def modification_lien(identifier):
     # sinon en méthode POST : 
     else: 
         personneOrigine = request.form.get("link_1_person", None)
-        personneUnique = Person.query.get(personneOrigine)
         
         status, data = Link.modifier_link(
             id = identifier,
@@ -175,7 +174,7 @@ def modification_lien(identifier):
 
         if status is True :
             flash("Modification réussie !", "success")
-            return render_template("pages/notice.html", unique=personneUnique, listLien=personneUnique.link_pers1)
+            return redirect("/person/" + str(personneOrigine) )
 
         else:
             flash("Les erreurs suivantes empêchent l'édition du lien : " + ",".join(data), "danger")

--- a/hoozhoo/templates/pages/creer_lien.html
+++ b/hoozhoo/templates/pages/creer_lien.html
@@ -18,31 +18,9 @@
         <label for="link_relation_type" class="font-weight-bold">Nature de la relation</label>
         <select class="custom-select d-block" id="link_relation_type" name="link_relation_type[]">
           <option selected>Choisir</option>
-          <option value="soeur de">soeur de</option>
-          <option value="frère de">frère de</option>
-          <option value="fille de">fille de</option>
-          <option value="fils de">fils de</option>
-          <option value="mère de">mère de</option>
-          <option value="père de">père de</option>
-          <option value="tante de">tante de</option>
-          <option value="oncle de">oncle de</option>
-          <option value="nièce de">nièce de</option>
-          <option value="neveu de">neveu de</option>
-          <option value="cousine ou cousin de">cousine ou cousin de</option>
-          <option value="petite-fille de">petite-fille de</option>
-          <option value="petit-fils de">petit-fils de</option>
-          <option value="grand-mère de">grand-mère de</option>
-          <option value="grand-père de">grand-père de</option>
-          <option value="arrière-grand-mère de">arrière-grand-mère de</option>
-          <option value="arrière-grand-père de">arrière-grand-père de</option>
-          <option value="relation intime occasionnelle avec">relation intime occasionnelle avec</option>
-          <option value="relation intime sérieuse avec">relation intime sérieuse avec</option>
-          <option value="esclave de">esclave de</option>
-          <option value="esclave libéré de">esclave libéré de</option>
-          <option value="femme libérée de">femme libérée de</option>
-          <option value="homme libéré de">homme libéré de</option>
-          <option value="ennemi de">ennemi de</option>
-          <option value="ami avec">ami avec</option>
+          {% for lien in listRelation %}
+          <option value="{{lien.relation_type_id}}">{{lien.relation_type_name}}</option>
+          {% endfor %}
         </select>
       </div>
 
@@ -76,31 +54,9 @@
                   <div class="col-sm">
                     <select class="custom-select d-block" id="link_relation_type" name="link_relation_type[]">
                       <option selected>Choisir</option>
-                      <option value="soeur de">soeur de</option>
-                      <option value="frère de">frère de</option>
-                      <option value="fille de">fille de</option>
-                      <option value="fils de">fils de</option>
-                      <option value="mère de">mère de</option>
-                      <option value="père de">père de</option>
-                      <option value="tante de">tante de</option>
-                      <option value="oncle de">oncle de</option>
-                      <option value="nièce de">nièce de</option>
-                      <option value="neveu de">neveu de</option>
-                      <option value="cousine ou cousin de">cousine ou cousin de</option>
-                      <option value="petite-fille de">petite-fille de</option>
-                      <option value="petit-fils de">petit-fils de</option>
-                      <option value="grand-mère de">grand-mère de</option>
-                      <option value="grand-père de">grand-père de</option>
-                      <option value="arrière-grand-mère de">arrière-grand-mère de</option>
-                      <option value="arrière-grand-père de">arrière-grand-père de</option>
-                      <option value="relation intime occasionnelle avec">relation intime occasionnelle avec</option>
-                      <option value="relation intime sérieuse avec">relation intime sérieuse avec</option>
-                      <option value="esclave de">esclave de</option>
-                      <option value="esclave libéré de">esclave libéré de</option>
-                      <option value="femme libérée de">femme libérée de</option>
-                      <option value="homme libéré de">homme libéré de</option>
-                      <option value="ennemi de">ennemi de</option>
-                      <option value="ami avec">ami avec</option>
+          {% for lien in listRelation %}
+          <option value="{{lien.relation_type_id}}">{{lien.relation_type_name}}</option>
+          {% endfor %}
                     </select>
                   </div>
 

--- a/hoozhoo/templates/pages/modification_lien.html
+++ b/hoozhoo/templates/pages/modification_lien.html
@@ -1,0 +1,59 @@
+{% extends "conteneur.html" %}
+{% block titre %}| Editer un lien{% endblock %}
+{% block corps %}
+
+<h1 class="mt-3">Editer un lien</h1>
+<p>Modifier le formulaire ci-dessous et cliquez sur "Enregistrer" pour éditer un lien.</p>
+
+<form class="form container-fluid mt-3" id="new-link-container" method="POST" action="{{url_for('modification_lien', identifier=unique.link_id)}}">
+  <div class="row">
+  <button type="submit" class="btn btn-secondary btn-block col-md-2 mx-auto mb-4 mt-3">Enregistrer</button>
+  </div>
+
+  <div class="new-link-div col-md-10 row mb-3 mx-auto form-group">
+      <div class="col-sm">
+        <label for="link_person1" class="font-weight-bold">Personne 1 (ID)</label>
+        <input type="text" class="form-control" id="link_person1" name="link_1_person" value="{{unique.link_person1_id}}" readonly />
+      </div>
+
+      <div class="col-sm">
+        <label for="link_relation_type" class="font-weight-bold">Nature de la relation</label>
+        <select class="custom-select d-block" id="link_relation_type" name="link_relation_type">
+          <option selected value="{{relation_name}}">{{relation_name}}</option>
+          <option disabled>__ Choisir __</option>
+          <option value="soeur de">soeur de</option>
+          <option value="frère de">frère de</option>
+          <option value="fille de">fille de</option>
+          <option value="fils de">fils de</option>
+          <option value="mère de">mère de</option>
+          <option value="père de">père de</option>
+          <option value="tante de">tante de</option>
+          <option value="oncle de">oncle de</option>
+          <option value="nièce de">nièce de</option>
+          <option value="neveu de">neveu de</option>
+          <option value="cousine ou cousin de">cousine ou cousin de</option>
+          <option value="petite-fille de">petite-fille de</option>
+          <option value="petit-fils de">petit-fils de</option>
+          <option value="grand-mère de">grand-mère de</option>
+          <option value="grand-père de">grand-père de</option>
+          <option value="arrière-grand-mère de">arrière-grand-mère de</option>
+          <option value="arrière-grand-père de">arrière-grand-père de</option>
+          <option value="relation intime occasionnelle avec">relation intime occasionnelle avec</option>
+          <option value="relation intime sérieuse avec">relation intime sérieuse avec</option>
+          <option value="esclave de">esclave de</option>
+          <option value="esclave libéré de">esclave libéré de</option>
+          <option value="femme libérée de">femme libérée de</option>
+          <option value="homme libéré de">homme libéré de</option>
+          <option value="ennemi de">ennemi de</option>
+          <option value="ami avec">ami avec</option>
+        </select>
+      </div>
+
+      <div class="col-sm">
+        <label for="link_person2" class="font-weight-bold">Personne 2 (ID)</label>
+        <input type="text" class="form-control" id="link_person2" name="link_2_person" value="{{unique.link_person2_id}}" />
+      </div>
+    </div>
+</form>
+
+{% endblock %}

--- a/hoozhoo/templates/pages/modification_lien.html
+++ b/hoozhoo/templates/pages/modification_lien.html
@@ -1,5 +1,5 @@
 {% extends "conteneur.html" %}
-{% block titre %}| Editer un lien{% endblock %}
+{% block titre %}| Edition de liens{% endblock %}
 {% block corps %}
 
 <h1 class="mt-3">Editer un lien</h1>

--- a/hoozhoo/templates/pages/modification_lien.html
+++ b/hoozhoo/templates/pages/modification_lien.html
@@ -19,33 +19,13 @@
       <div class="col-sm">
         <label for="link_relation_type" class="font-weight-bold">Nature de la relation</label>
         <select class="custom-select d-block" id="link_relation_type" name="link_relation_type">
-          <option selected value="{{relation_name}}">{{relation_name}}</option>
-          <option disabled>__ Choisir __</option>
-          <option value="soeur de">soeur de</option>
-          <option value="frère de">frère de</option>
-          <option value="fille de">fille de</option>
-          <option value="fils de">fils de</option>
-          <option value="mère de">mère de</option>
-          <option value="père de">père de</option>
-          <option value="tante de">tante de</option>
-          <option value="oncle de">oncle de</option>
-          <option value="nièce de">nièce de</option>
-          <option value="neveu de">neveu de</option>
-          <option value="cousine ou cousin de">cousine ou cousin de</option>
-          <option value="petite-fille de">petite-fille de</option>
-          <option value="petit-fils de">petit-fils de</option>
-          <option value="grand-mère de">grand-mère de</option>
-          <option value="grand-père de">grand-père de</option>
-          <option value="arrière-grand-mère de">arrière-grand-mère de</option>
-          <option value="arrière-grand-père de">arrière-grand-père de</option>
-          <option value="relation intime occasionnelle avec">relation intime occasionnelle avec</option>
-          <option value="relation intime sérieuse avec">relation intime sérieuse avec</option>
-          <option value="esclave de">esclave de</option>
-          <option value="esclave libéré de">esclave libéré de</option>
-          <option value="femme libérée de">femme libérée de</option>
-          <option value="homme libéré de">homme libéré de</option>
-          <option value="ennemi de">ennemi de</option>
-          <option value="ami avec">ami avec</option>
+          {% for lien in listRelation %}
+            {% if lien.relation_type_id == unique.link_relation_type_id %}
+            <option value="{{lien.relation_type_id}}" selected>{{lien.relation_type_name}}</option>
+            {% else %}
+            <option value="{{lien.relation_type_id}}">{{lien.relation_type_name}}</option>
+            {% endif %}
+          {% endfor %}
         </select>
       </div>
 

--- a/hoozhoo/templates/pages/notice.html
+++ b/hoozhoo/templates/pages/notice.html
@@ -5,9 +5,9 @@
 
 {% block corps %}
     {% if unique %}
-        <h1>{{unique.person_name}} {{unique.person_firstname}} {{unique.person_nickname}}</h1>
+        <h1 class="mt-3 mb-4">{{unique.person_name}} {{unique.person_firstname}} {{unique.person_nickname}}</h1>
 
-        <div class="row">
+        <div class="row border border-top-0 border-right-0 border-left-0 border-secondary pb-2">
             <div class="col-4"> <p class="font-weight-bold"> Identifiant Hoozhoo</p></div>
           <div class="col-8">{{unique.person_id}}</div>
           <div class="w-100"></div>
@@ -36,13 +36,26 @@
           <div class="w-100"></div>
           <div class="col-4"> <p class="font-weight-bold">Identifiant Wikidata</p></div>
           <div class="col-8">{{unique.person_external_id}}</div>
-
+        </div>
+        <div class="row pt-3">
+          <h2 class="pb-2">Liens avec les autres personnes</h2>
         {% for lien in listLien %}
-            <div class="w-100"></div>
-            <div class="col-4"> <p class="font-weight-bold">
-                {{lien.relations.relation_type_name}}</p>
+            <div class="w-100">
+              
             </div>
-            <div class="col-8"><a href="{{url_for('notice', identifier=lien.person2.person_id)}}">{{lien.person2.person_name}} {{lien.person2.person_firstname}} {{lien.person2.person_nickname}}</a></div>
+            <div class="col-4"> 
+              <p class="font-weight-bold">{{lien.relations.relation_type_name}}</p>
+            </div>
+            <div class="col-3">
+              <a href="{{url_for('notice', identifier=lien.person2.person_id)}}">{{lien.person2.person_name}} {{lien.person2.person_firstname}} {{lien.person2.person_nickname}}</a>
+            </div>
+            <div class="col-1">
+              <a href="{{ url_for('modification_lien', identifier=lien.link_id) }}" type="button" class="btn btn-outline-secondary btn-sm" title="éditer"><i class="fa fa-edit"></i></a>
+            </div>
+            <div class="col-1">
+              <a href="#" type="button" class="btn btn-outline-danger btn-sm" title="supprimer"><i class="fa fa-trash"></i></a>
+            </div>
+
             {% endfor %}
         </div>
 
@@ -51,10 +64,14 @@
         <p>La base de données est en cours de constitution</p>
     {% endif %}
 
-    <div class="row">
+    <div class="row pt-3">
     <div class="w-100"></div>
-        <div class="col-4 "> <a href="{{ url_for('modification', identifier=unique.person_id) }}" class="btn btn-secondary">Modifier la notice de la personne</a></div>
-        <div class="col-4"> <p class="font-weight-bold"><a href="{{url_for('creer_lien')}}" class="btn btn-secondary">Créer des liens entre les personnes</a></div>
+        <div class="col-4 ">
+          <a href="{{ url_for('modification', identifier=unique.person_id) }}" class="btn btn-secondary">Modifier la notice de la personne</a>
+        </div>
+        <div class="col-4"> <p class="font-weight-bold">
+          <a href="{{url_for('creer_lien')}}" class="btn btn-secondary">Créer de nouveaux liens</a>
+        </div>
 
 
 {% endblock %}


### PR DESCRIPTION
Je vous envoie dès maintenant un aperçu de la page pour modifier un lien : 
- j'étais partie dans l'idée de pouvoir tout modifier d'un coup mais au bout du compte cela me complique la vie pour mettre à jour le groupe de liens édités : j'arrive uniquement à créer des doublons mis à jour... 
- du coup j'ai modifié la notice pour qu'on puisse modifier les liens un par un, en anticipant la fonctionnalité "supprimer le lien". 

Vous pouvez voir la page en méthode GET, mais je travaille encore sur la méthode POST.  

Du coup attendez mes prochains commits avant de merger !