### PR TITLE
Maj creerpersonne

### DIFF
--- a/hoozhoo/modeles/donnees.py
+++ b/hoozhoo/modeles/donnees.py
@@ -12,14 +12,14 @@ class Person(db.Model):
     person_name = db.Column(db.Text)
     person_firstname = db.Column(db.Text)
     person_nickname = db.Column(db.Text)
-    person_description = db.Column(db.Text, nullable=False)
+    person_nativename = db.Column(db.Text)
+    person_country = db.Column(db.Text)
+    person_language = db.Column(db.Text)
     person_birthdate = db.Column(db.String(12))
     person_deathdate = db.Column(db.String(12))
     person_gender = db.Column(db.Text, nullable=False)
-    person_country = db.Column(db.Text)
-    person_language = db.Column(db.Text)
     person_occupations = db.Column(db.Text)
-    person_nativename = db.Column(db.Text)
+    person_description = db.Column(db.Text, nullable=False)
     person_external_id = db.Column(db.String(12), nullable=False)
 # Jointure
     authorships_p = db.relationship("Authorship_person", back_populates="person")
@@ -27,15 +27,45 @@ class Person(db.Model):
     link_pers2 = db.relationship("Link", primaryjoin="Person.person_id==Link.link_person2_id")
 
     @staticmethod
-    def create_person(nom, prenom, surnom, description, date_naissance, date_deces, genre, id_externes):
+    def create_person(nom, prenom, surnom, nom_naissance, nationalite, langues, date_naissance, date_deces, fonctions, description, genre, id_externes):
         # on vérifie qu'au moins un des trois champs (nom, prénom et surnom) est rempli ainsi que celui de la description qui est obligatoire
         errors = []
         if not (nom or prenom or surnom):
             errors.append("Un des trois champs (nom, prénom, surnom) est obligatoire")
+        # vérifier que le champ genre est bien coché
+        if not genre:
+            errors.append("Le champ genre est obligatoire")
         # vérifier que le champ description est bien rempli
         if not description:
             errors.append("Le champ description est obligatoire")
+        # vérifier que le champ wikidata id est bien rempli
+        if not id_externes:
+            errors.append("L'identifiant Wikidata est obligatoire")
         # si on a au moins une erreur
+        if len(errors) > 0:
+            return False, errors
+
+        #vérifier que la taille des caractères insérés (nom, prenonm, surnom) ne dépasse pas la limite acceptée par mysql
+        if len(nom) > 255 or len(prenom) > 255 or len(surnom) > 255 :
+            errors.append("La taille des caractères du nom, ou du prénom ou du surnon a été dépassée")
+        if len(errors) > 0:
+            return False, errors
+
+        #vérifier que la taille des caractères insérés (date) ne dépasse pas la limite acceptée par mysql
+        if len(date_naissance) > 12 or len(date_deces) > 12:
+            errors.append("La taille des caractères des dates a été dépassée")
+        if len(errors) > 0:
+            return False, errors
+
+        #vérifier que la taille des caractères insérés (wikidata id) ne dépasse pas la limite acceptée par mysql
+        if len(id_externes) > 12 :
+            errors.append("La taille des caractères du champs Wikidata ID a été dépassée")
+        if len(errors) > 0:
+            return False, errors
+
+        #vérifier que l'ID Wikidata commence par Q
+        if id_externes[0] != "Q" :
+            errors.append("L'ID Wikidata doit commencer par 'Q'")
         if len(errors) > 0:
             return False, errors
 
@@ -49,15 +79,20 @@ class Person(db.Model):
         if len(errors) > 0:
             return False, errors
 
+
         # Sinon, on crée une nouvelle personne dans la table Person
         created_person = Person(
             person_name=nom,
             person_firstname=prenom,
             person_nickname=surnom,
-            person_description=description,
+            person_nativename=nom_naissance,
+            person_country=nationalite,
+            person_language=langues,
             person_birthdate=date_naissance,
             person_deathdate=date_deces,
             person_gender=genre,
+            person_occupations=fonctions,
+            person_description=description,
             person_external_id=id_externes
         )
 

--- a/hoozhoo/modeles/utilisateurs.py
+++ b/hoozhoo/modeles/utilisateurs.py
@@ -14,4 +14,54 @@ class User(UserMixin, db.Model):
     author_person = db.relationship("Authorship_person", back_populates="user_person")
     author_link = db.relationship("Authorship_link", back_populates="user_link")
 
-# AJOUTER  LES METHODES STATIQUES
+    @staticmethod
+    def creer(login, email, nom, motdepasse):
+	    """ Crée un compte utilisateur-rice. Retourne un tuple (booléen, User ou liste).
+	    Si il y a une erreur, la fonction renvoie False suivi d'une liste d'erreur
+	    Sinon, elle renvoie True suivi de la donnée enregistrée
+
+	    :param login: Login de l'utilisateur-rice
+	    :param email: Email de l'utilisateur-rice
+	    :param nom: Nom de l'utilisateur-rice
+	    :param motdepasse: Mot de passe de l'utilisateur-rice (Minimum 6 caractères)
+
+	    """
+	    erreurs = []
+	    if not login:
+	        erreurs.append("Le login fourni est vide")
+	    if not email:
+	        erreurs.append("L'email fourni est vide")
+	    if not nom:
+	        erreurs.append("Le nom fourni est vide")
+	    if not motdepasse or len(motdepasse) < 6:
+	        erreurs.append("Le mot de passe fourni est vide ou trop court")
+
+	    # On vérifie que personne n'a utilisé cet email ou ce login
+	    uniques = User.query.filter(
+	        db.or_(User.user_email == email, User.user_login == login)
+	    ).count()
+	    if uniques > 0:
+	        erreurs.append("L'email ou le login sont déjà inscrits dans notre base de données")
+
+	    # Si on a au moins une erreur
+	    if len(erreurs) > 0:
+	        return False, erreurs
+
+	    # On crée un utilisateur
+	    utilisateur = User(
+	        user_name=nom,
+	        user_login=login,
+	        user_email=email,
+	        user_password=generate_password_hash(motdepasse)
+	    )
+
+	    try:
+	        # On l'ajoute au transport vers la base de données
+	        db.session.add(utilisateur)
+	        # On envoie le paquet
+	        db.session.commit()
+
+	        # On renvoie l'utilisateur
+	        return True, utilisateur
+	    except Exception as erreur:
+	        return False, [str(erreur)]

--- a/hoozhoo/routes/generic.py
+++ b/hoozhoo/routes/generic.py
@@ -113,7 +113,7 @@ def modification (identifier):
 
 
 
-@app.route("/creer_personne", methods=["GET", "POST"])
+@app.route("/creer-personne", methods=["GET", "POST"])
 #@login_required #désactivation pour test
 def creer_personne():
     """ route permettant à l'utilisateur de créer une notice personne """

--- a/hoozhoo/routes/generic.py
+++ b/hoozhoo/routes/generic.py
@@ -124,9 +124,13 @@ def creer_personne():
         nom=request.form.get("nom", None), 
         prenom=request.form.get("prenom", None),
         surnom=request.form.get("surnom", None),
+        nom_naissance=request.form.get("nom_naissance", None),
         date_naissance=request.form.get("date_naissance", None),
-        date_deces=request.form.get("date_mort", None),
+        date_deces=request.form.get("date_deces", None),
+        nationalite=request.form.get("nationalite", None),
+        langues=request.form.get("langues", None),
         genre=request.form.get("genre", None),
+        fonctions=request.form.get("fonctions", None),
         description=request.form.get("description", None),
         id_externes=request.form.get("id_externes", None)
         )
@@ -134,7 +138,7 @@ def creer_personne():
 
         if status is True:
             flash("Création d'une nouvelle personne réussie !", "success")
-            return redirect("/creer_personne")
+            return redirect("/creer-personne")
         else:
             flash("La création d'une nouvelle personne a échoué pour les raisons suivantes : " + ", ".join(data), "danger")
             return render_template("pages/creer_personne.html")

--- a/hoozhoo/routes/generic.py
+++ b/hoozhoo/routes/generic.py
@@ -148,3 +148,25 @@ def creer_personne():
 def contact():
     return render_template("pages/contact.html")
 
+
+@app.route("/inscription", methods=["GET", "POST"])
+def inscription():
+    """ Route gérant les inscriptions
+    """
+    # Si on est en POST, cela veut dire que le formulaire a été envoyé
+    if request.method == "POST":
+        statut, donnees = User.creer(
+            login=request.form.get("login", None),
+            email=request.form.get("email", None),
+            nom=request.form.get("nom", None),
+            motdepasse=request.form.get("motdepasse", None)
+        )
+        if statut is True:
+            flash("Enregistrement effectué. Identifiez-vous maintenant", "success")
+            return redirect("/")
+        else:
+            flash("Les erreurs suivantes ont été rencontrées : " + ",".join(donnees), "error")
+            return render_template("pages/inscription.html")
+    else:
+        return render_template("pages/inscription.html")
+

--- a/hoozhoo/templates/conteneur.html
+++ b/hoozhoo/templates/conteneur.html
@@ -16,7 +16,7 @@
 							<a class="nav-link" href="{{url_for("index")}}">Index</a>
 						</li>
 						<li class="nav-item">
-							<a class="nav-link" href="#">Contribuer</a>
+							<a class="nav-link" href="{{url_for("creer_personne")}}">Créer une personne</a>
 						</li>
 						<li class="nav-item">
 							<a class="nav-link" href="{{url_for("creer_lien")}}">Créer un lien</a>
@@ -26,9 +26,6 @@
 						</li>
 						<li class="nav-item">
 							<a class="nav-link" href="#">Déconnexion ()</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="#">Contact</a>
 						</li>
 					</ul>
 				<form class="form-inline" action="#" method="GET">

--- a/hoozhoo/templates/pages/creer_personne.html
+++ b/hoozhoo/templates/pages/creer_personne.html
@@ -32,16 +32,38 @@
       </div>
     </div>
     <div class="form-group row">
+      <div class="form-group col-lg-6">
+        <label for="nom_naissance" class="col-lg-4 col-form-label">Nom de naissance</label>
+      <div class="col">
+        <input type="text" class="form-control" id="nom_naissance" name="nom_naissance" placeholder="Nom de naissance">
+      </div>
+      </div>
+    </div>
+    <div class="form-group row">
       <div class="form-group col">
         <label for="date naissance" class="col-lg-4 col-form-label">Date de naissance</label>
       <div class="col">
-        <input type="text" class="form-control" id="date_naissance" name="date_naissance" placeholder="JJ-MM-AAAA">
+        <input type="text" class="form-control" id="date_naissance" name="date_naissance">
       </div>
       </div>
       <div class="form-group col">
         <label for="date_deces" class="col-lg-4 col-form-label">Date de décès</label>
       <div class="col">
-        <input type="text" class="form-control" id="date_deces" name="date_deces" placeholder="JJ-MM-AAAA">
+        <input type="text" class="form-control" id="date_deces" name="date_deces">
+      </div>
+      </div>
+    </div>
+    <div class="form-group row">
+      <div class="form-group col">
+        <label for="nationalite" class="col-lg-4 col-form-label">Nationalité</label>
+      <div class="col">
+        <input type="text" class="form-control" id="nationalite" name="nationalite" placeholder="Nationalité">
+      </div>
+      </div>
+      <div class="form-group col">
+        <label for="langues" class="col-lg-7 col-form-label">Langues parlées, écrites ou signées</label>
+      <div class="col">
+        <input type="text" class="form-control" id="langues" name="langues" placeholder="Langues parlée, écrites ou signées">
       </div>
       </div>
     </div>
@@ -59,6 +81,14 @@
       <div class="form-check form-check-inline col-lg-2">
         <input class="form-check-input" type="radio" name="genre" id="inconnu" value="inconnu">
         <label class="form-check-label" for="inconnu">Inconnu</label>
+      </div>
+      </div>
+    </div>
+    <div class="form-group row">
+      <div class="form-group col-lg-6">
+        <label for="fonctions" class="col-lg-4 col-form-label">Fonction(s)</label>
+      <div class="col">
+        <input type="text" class="form-control" id="fonctions" name="fonctions" placeholder="Fonction(s)">
       </div>
       </div>
     </div>

--- a/hoozhoo/templates/pages/inscription.html
+++ b/hoozhoo/templates/pages/inscription.html
@@ -1,0 +1,44 @@
+{% extends "conteneur.html" %}
+
+{% block titre %}| Inscription{%endblock%}
+
+{% block corps %}
+
+<h1 class="mt-3">Inscription</h1>
+<p>Complétez le formulaire et cliquez sur "S'inscrire".</p>
+<form class="form" method="POST" action="{{url_for("inscription")}}">
+  <div class="form-group row">
+    <label for="register-login" class="col-sm-2 col-form-label">Nom d'utilisateur</label>
+    <div class="col-sm-10">
+      <input type="text" class="form-control" id="register-login" name="login" placeholder="Nom d'utilisateur pour se connecter">
+    </div>
+  </div>
+  <div class="form-group row">
+    <label for="register-nom" class="col-sm-2 col-form-label">Nom</label>
+    <div class="col-sm-10">
+      <input type="text" class="form-control" id="register-nom" placeholder="Votre nom pour les crédits" name="nom">
+    </div>
+  </div>
+  <div class="form-group row">
+    <label for="register-email" class="col-sm-2 col-form-label">Email</label>
+    <div class="col-sm-10">
+      <input type="email" class="form-control" id="register-email" placeholder="email@example.com" name="email">
+    </div>
+  </div>
+  <div class="form-group row">
+    <label for="register-password" class="col-sm-2 col-form-label">Mot de passe</label>
+    <div class="col-sm-10">
+      <input type="password" class="form-control" id="register-password" placeholder="Mot de passe" name="motdepasse">
+    </div>
+  </div>
+  <div class="form-group row">
+    <label for="register-password" class="col-sm-2 col-form-label">Confirmer votre mot de passe</label>
+    <div class="col-sm-10">
+      <input type="password" class="form-control" id="register-password" placeholder="Mot de passe" name="motdepasse">
+    </div>
+  </div>
+  <div class="form-group row">
+    <button type="submit" class="btn btn-secondary mx-auto">S'inscrire</button>
+  </div>
+</form>
+{% endblock %}


### PR DESCRIPTION
Modifications apportées :
- navbar : correction de l'onglet 'contribuer' en 'créer une personne' (harmonisation avec ce qu'avait fait Alix) + ajout du lien url (changement de url 'creer_personne' en 'creer-personne')
- ajout des 4 champs dans le formulaire de création personne : **attention!**, comme nous n'avons pas défini les dénominations de ces champs pour le moment ce sont les noms provisoires
    #61 + suppression dans les placeholder des mentions JJ-MM-YYYY pour les dates
- màj de la méthode statique :
    - nom, prenom ou surnom obligatoire
    - genre et description obligatoires
    - wikidata id obligatoire avec vérification qu'il commence bien par un Q et max 12 caractères
    - vérification du nombre de caractères (//SQL)
