### PR TITLE
Ajout de la fonction suppression de lien

### DIFF
--- a/hoozhoo/modeles/donnees.py
+++ b/hoozhoo/modeles/donnees.py
@@ -321,8 +321,10 @@ class Link(db.Model):
         :param link_id : un identifiant numérique du lien
         """
 
+        lien = Link.query.get(link_id)
+
         try:
-            db.session.delete(link_id)
+            db.session.delete(lien)
             db.session.commit()
             return True
         except Exception as failed:

--- a/hoozhoo/modeles/donnees.py
+++ b/hoozhoo/modeles/donnees.py
@@ -336,7 +336,6 @@ class Authorship_link(db.Model):
     authorship_link_id = db.Column(db.Integer, nullable=True, autoincrement=True, primary_key=True)
     authorship_link_user_id = db.Column(db.Integer, db.ForeignKey('user.user_id'))
     authorship_link_link_id = db.Column(db.Integer, db.ForeignKey('link.link_id'))
-    link_relation_type_id = db.Column(db.Integer, db.ForeignKey('relation_type.relation_type_id'))
     authorship_link_date = db.Column(db.DateTime, default=datetime.datetime.utcnow)
 # Jointure
     user_link = db.relationship("User", back_populates="author_link")

--- a/hoozhoo/modeles/donnees.py
+++ b/hoozhoo/modeles/donnees.py
@@ -314,6 +314,21 @@ class Link(db.Model):
         except Exception as error_modification:
             return False, [str(error_modification)]
 
+    @staticmethod
+    def delete_link(link_id):
+        """
+        Supprime un lien dans la bae de données, retourne un booléen : True si la suppression a réussi, sinon False.
+        :param link_id : un identifiant numérique du lien
+        """
+
+        try:
+            db.session.delete(link_id)
+            db.session.commit()
+            return True
+        except Exception as failed:
+            print(failed)
+            return False
+
 class Authorship_link(db.Model):
     __tablename__ = "authorship_link"
     authorship_link_id = db.Column(db.Integer, nullable=True, autoincrement=True, primary_key=True)

--- a/hoozhoo/routes/generic.py
+++ b/hoozhoo/routes/generic.py
@@ -195,6 +195,14 @@ def suppression_lien(identifier):
         return render_template("pages/suppr_lien.html", unique=lienUnique, listRelation=listRelation)
 
     else:
-        flash("Lien supprimé !", "success")
-        return redirect("/person/" + str(lienUnique.link_person1_id))
+
+        status = Link.delete_link(link_id=identifier)
+
+        if status is True : 
+            flash("Lien supprimé !", "success")
+            return redirect("/person/" + str(lienUnique.link_person1_id))
+
+        else: 
+            flash("La suppression a échoué.", "danger")
+            return redirect("/person/" + str(lienUnique.link_person1_id))
 

--- a/hoozhoo/routes/generic.py
+++ b/hoozhoo/routes/generic.py
@@ -179,3 +179,22 @@ def modification_lien(identifier):
         else:
             flash("Les erreurs suivantes empêchent l'édition du lien : " + ",".join(data), "danger")
             return render_template("pages/modification_lien.html", unique=lienUnique, listRelation=listRelation)
+
+
+
+@app.route("/confirmer-supprimer/<int:identifier>", methods=["GET", "POST"]) 
+def suppression_lien(identifier):
+    """
+    Route qui affiche les informations du lien à supprimer et qui demande confirmation
+    :param identifier : identifiant numérique du lien
+    """
+    listRelation = Relation_type.query.all()
+    lienUnique = Link.query.get(identifier)
+
+    if request.method == "GET":
+        return render_template("pages/suppr_lien.html", unique=lienUnique, listRelation=listRelation)
+
+    else:
+        flash("Lien supprimé !", "success")
+        return redirect("/person/" + str(lienUnique.link_person1_id))
+

--- a/hoozhoo/templates/pages/notice.html
+++ b/hoozhoo/templates/pages/notice.html
@@ -53,7 +53,7 @@
               <a href="{{ url_for('modification_lien', identifier=lien.link_id) }}" type="button" class="btn btn-outline-secondary btn-sm" title="éditer"><i class="fa fa-edit"></i></a>
             </div>
             <div class="col-1">
-              <a href="#" type="button" class="btn btn-outline-danger btn-sm" title="supprimer"><i class="fa fa-trash"></i></a>
+              <a href="{{ url_for('suppression_lien', identifier=lien.link_id) }}" class="btn btn-outline-danger btn-sm" title="supprimer"><i class="fa fa-trash"></i></a>
             </div>
 
             {% endfor %}

--- a/hoozhoo/templates/pages/suppr_lien.html
+++ b/hoozhoo/templates/pages/suppr_lien.html
@@ -1,0 +1,41 @@
+{% extends "conteneur.html" %}
+{% block titre %}
+    {%if unique %}| Suppression d'un lien {% endif %}
+{% endblock %}
+
+{% block corps %}
+<div class="mt-5 container">
+
+	<div class="row">
+		<div class="col-md mt-3">
+			<p>Merci de confirmer la suppression du lien suivant :</p>
+		</div>
+		<div class="col-md mt-3">
+			<strong>
+				<span class="mr-1">
+					{% if unique.person1.person_firstname %}{{unique.person1.person_firstname}}{% endif %}
+					{% if unique.person1.person_name %}{{unique.person1.person_name}}{% endif %}
+					{% if unique.person1.person_nickname %}{{unique.person1.person_nickname}}{% endif %}
+				</span>
+				<span>{{unique.relations.relation_type_name}}</span>
+				<span class="ml-1">
+					{% if unique.person2.person_firstname %}{{unique.person2.person_firstname}}{% endif %}
+					{% if unique.person2.person_name %}{{unique.person2.person_name}}{% endif %}
+					{% if unique.person2.person_nickname %}{{unique.person2.person_nickname}}{% endif %}
+				</span>
+			</strong>
+		</div>
+		<div class="col-md container mt-3">
+				<div class="row">
+				<form class="col-3 mr-2 " method="POST" action="{{url_for('suppression_lien', identifier=unique.link_id) }}">
+				<button type="submit" class="btn btn-success btn-sm">Confirmer</button>
+				</form>
+				<form class="col-3 ml-2" method="GET" action="{{ url_for('notice', identifier=unique.link_person1_id) }}">
+				<button type="submit" class="btn btn-danger btn-sm">Annuler</button>
+			</form>
+		</div>
+			</div>
+		</div>
+	</div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Voici la fonction de suppression de lien.  
Au passage, j'ai corrigé la table Authorship_link dans donnee.py car nous avions systématiquement l'erreur suivante :  
```
sqlalchemy.exc.InvalidRequestError: This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (_mysql_exceptions.OperationalError) (1054, "Unknown column 'authorship_link.link_relation_type_id' in 'field list'") [SQL: 'SELECT authorship_link.authorship_link_id AS authorship_link_authorship_link_id, authorship_link.authorship_link_user_id AS authorship_link_authorship_link_user_id, authorship_link.authorship_link_link_id AS authorship_link_authorship_link_link_id, authorship_link.link_relation_type_id AS authorship_link_link_relation_type_id, authorship_link.authorship_link_date AS authorship_link_authorship_link_date \nFROM authorship_link \nWHERE %s = authorship_link.authorship_link_link_id'] [parameters: (1,)] (Background on this error at: http://sqlalche.me/e/e3q8
```

Il y avait donc une ligne en trop dans cette table : `link_relation_type_id`. 