### PR TITLE
ajout du controle de l'id wikidata lors de la création personne

### DIFF
--- a/hoozhoo/modeles/donnees.py
+++ b/hoozhoo/modeles/donnees.py
@@ -75,6 +75,12 @@ class Person(db.Model):
         if personne > 0:
             errors.append("La personne est déjà inscrite dans la base de données")
 
+        # vérifier si l'ID wikidata existe déjà 
+        personne = Person.query.filter(Person.person_external_id == id_externes).count()
+
+        if personne > 0:
+            errors.append("L'identifiant Wikidata est déjà utilisé")
+
         # Si on a au moins une erreur
         if len(errors) > 0:
             return False, errors


### PR DESCRIPTION
#58 
Je viens d'ajouter le test dans la méthode statique qui permet la vérification de l'id Wikidata afin que ce ne soit pas possible de créer 2 personnes différentes avec le même id Wikidata.

Il y avait 2 façons de faire cette correction : 
- modifier pour la partie vérification personne le `db.and en db.or` et ajouter `Person.person_external_id == id_externes` mais le message d'erreur mentionné seulement que la personne existait dans la base
- faire un autre test seulement sur l'id Wikidata avec son propre message d'erreur par la suite

J'ai plutôt opté pour la 2e solution mais on peut faire l'autre si vous préférez