### PR TITLE
ajout erreur 404 pour API recherche (mot-cle)

### DIFF
--- a/hoozhoo/routes/api.py
+++ b/hoozhoo/routes/api.py
@@ -38,11 +38,9 @@ def json_recherche():
     else:
         query = Person.query
 
-    try:
-        resultats = query.all()
 
-    except Exception:
-        return Json_404()
+# vérification de la présence d'un résultat : s'il n'y en a pas, retourne une erreur 404
+    resultats = query.all()
 
     if len(resultats) == 0 :
     	return Json_404()

--- a/hoozhoo/routes/api.py
+++ b/hoozhoo/routes/api.py
@@ -44,10 +44,13 @@ def json_recherche():
     except Exception:
         return Json_404()
 
-    dict_resultats = {
-        "resultats": [
-            personne.person_to_json()
-            for personne in resultats
+    if len(resultats) == 0 :
+    	return Json_404()
+    else :
+    	dict_resultats = {
+	        "resultats": [
+	            personne.person_to_json()
+	            for personne in resultats
         ]
     }
 


### PR DESCRIPTION
Je viens d'ajouter l'erreur 404 pour l'API recherche par mot-clé, normalement cela fonctionne.
Par contre, je ne suis pas sûre d'avoir compris tout le code... donc il est possible que j'ai oublié de supprimer des parties qui ne servent plus avec mon ajout